### PR TITLE
Numpy 1.16.3 changes the allow_pickle default to False.

### DIFF
--- a/psytrack/examples/ExampleNotebook.ipynb
+++ b/psytrack/examples/ExampleNotebook.ipynb
@@ -247,7 +247,7 @@
    ],
    "source": [
     "# Extract premade dataset from npz\n",
-    "D = np.load('sampleRatData.npz')['D'].item()\n",
+    "D = np.load('sampleRatData.npz', allow_pickle=True)['D'].item()\n",
     "\n",
     "print(\"The keys of the dict for this example animal:\\n   \", list(D.keys()))\n"
    ]


### PR DESCRIPTION
'allow_pickle' needs to be True to load saved objects